### PR TITLE
fix: a typo

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
     <title>IPFS Check</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="tachyons.min.css"/>
+    <link rel="canonical" href="https://ipfs-check.on.fleek.co/">
 </head>
 <body class="sans-serif ma0">
 <header>
@@ -19,7 +20,7 @@
             Check the retrievability of CID from an IPFS peer
         </p>
         <p class="ma0 pv0 mt2 ph2 f5 fw4">
-            Paste in a host peers multiaddr and a Content ID, to check if if is expected to be retrievable
+            Paste in a host peers multiaddr and a Content ID, to check if it is expected to be retrievable
         </p>
     </section>
     <section class="bg-near-white">


### PR DESCRIPTION
@aschmahmann  this PR fixes a typo and adds a [canonical link](https://en.wikipedia.org/wiki/Canonical_link_element) to ensure the website gets deduplicated across all gateway search results and placed under a canonical URL.