### PR TITLE
Loop through found addrs manually & insert newlines

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -115,7 +115,8 @@
                     if (!foundAddr) {
                         outText += "❌ Could not find the given multiaddr in the dht. Instead found:\n"
 						for (const key in respObj.PeerFoundInDHT) {
-							outText += "      " + respObj.PeerFoundInDHT[key] + "\n"
+							outText += "\t" + key + "\n"
+
 						}
                     }
                     if (respObj.CidInDHT === true) {

--- a/web/index.html
+++ b/web/index.html
@@ -113,7 +113,10 @@
                         }
                     }
                     if (!foundAddr) {
-                        outText += "❌ Could not find the given multiaddr in the dht. Instead found: " + Object.keys(respObj.PeerFoundInDHT) + "\n"
+                        outText += "❌ Could not find the given multiaddr in the dht. Instead found:\n"
+						for (const key in respObj.PeerFoundInDHT) {
+							outText += "      " + respObj.PeerFoundInDHT[key] + "\n"
+						}
                     }
                     if (respObj.CidInDHT === true) {
                         outText += "✔ Found multihash adverised in the dht\n"


### PR DESCRIPTION
After using a pinning service in addition to my local node - I got back many found peers (but not the local node I was checking) in my ipfs-check output - which didn't wrap nicely onto newlines when using the Object.keys() output.

Before:
![image](https://user-images.githubusercontent.com/618519/147890400-fc79460c-b7a7-40d6-a1bf-ad2bd7460041.png)

After:
![image](https://user-images.githubusercontent.com/618519/147890386-5db0bfa4-1016-468c-a522-502b8fba3948.png)

_(warning - not a js dev - please double check my syntax!)_