### PR TITLE
fix libp2p initialization errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.2.4
 	github.com/libp2p/go-libp2p-core v0.11.0
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
-	github.com/libp2p/go-libp2p-quic-transport v0.15.2
+	github.com/libp2p/go-libp2p-quic-transport v0.15.2 // indirect
 	github.com/libp2p/go-libp2p-record v0.1.3
 	github.com/libp2p/go-msgio v0.1.0
 	github.com/multiformats/go-multiaddr v0.4.1

--- a/main.go
+++ b/main.go
@@ -21,11 +21,8 @@ import (
 	"github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	dhtpb "github.com/libp2p/go-libp2p-kad-dht/pb"
-	quict "github.com/libp2p/go-libp2p-quic-transport"
 	record "github.com/libp2p/go-libp2p-record"
 )
-
-var transportOpts = libp2p.ChainOptions(libp2p.DefaultTransports, libp2p.Transport(quict.NewTransport))
 
 type kademlia interface {
 	routing.Routing
@@ -34,10 +31,12 @@ type kademlia interface {
 
 func main() {
 	h, err := libp2p.New(
-		transportOpts,
 		libp2p.ConnectionManager(connmgr.NewConnManager(600, 900, time.Second*30)),
 		libp2p.ConnectionGater(&privateAddrFilterConnectionGater{}),
 	)
+	if err != nil {
+		panic(err)
+	}
 
 	d, err := fullrt.NewFullRT(h, "/ipfs",
 		fullrt.DHTOption(
@@ -128,7 +127,7 @@ func (d *daemon) runCheck(writer http.ResponseWriter, uristr string) error {
 
 	ctx := context.Background()
 
-	testHost, err := libp2p.New(transportOpts, libp2p.ConnectionGater(&privateAddrFilterConnectionGater{}))
+	testHost, err := libp2p.New(libp2p.ConnectionGater(&privateAddrFilterConnectionGater{}))
 	if err != nil {
 		return fmt.Errorf("server error: %w", err)
 	}


### PR DESCRIPTION
add missing error check on host creation and stop manually adding QUIC since it's now done by default