### PR TITLE
Add GitHub Action to publish the binary to GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: build and publish
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish-binary:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.17'
+
+    - name: Build binary
+      run: |
+        go version
+        go build .
+
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: latest
+        release_name: ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload binary to release
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./ipfs-check
+        asset_name: ipfs-check
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This will create a new GitHub Release each time you merge to `main`. It will also tag the commit as `latest` because it seems that you have to have a tag when you release. We can work on it if you want other things (such as creating a new release for every branch or for every PR).